### PR TITLE
CERT 8061 Add Celo chain support

### DIFF
--- a/src/quorum/apis/block_explorers/chains_api.py
+++ b/src/quorum/apis/block_explorers/chains_api.py
@@ -30,6 +30,7 @@ class ChainAPI:
         Chain.SCROLL: 534352,
         Chain.ZK: 324,
         Chain.LINEA: 59144,
+        Chain.CELO: 42220,
     }
 
     BASE_URL = "https://api.etherscan.io/v2/api?chainid={chain_id}&apikey={api_key}"

--- a/src/quorum/apis/governance/aave_governance.py
+++ b/src/quorum/apis/governance/aave_governance.py
@@ -20,6 +20,7 @@ CHAIN_ID_TO_CHAIN = {
     "534352": Chain.SCROLL,
     "324": Chain.ZK,
     "59144": Chain.LINEA,
+    "42220": Chain.CELO,
 }
 
 

--- a/src/quorum/apis/price_feeds/chainlink_api.py
+++ b/src/quorum/apis/price_feeds/chainlink_api.py
@@ -23,6 +23,8 @@ class ChainLinkAPI(PriceFeedProviderBase):
         Chain.POLY: "https://reference-data-directory.vercel.app/feeds-matic-mainnet.json",
         Chain.SCROLL: "https://reference-data-directory.vercel.app/feeds-ethereum-mainnet-scroll-1.json",
         Chain.ZK: "https://reference-data-directory.vercel.app/feeds-ethereum-mainnet-zksync-1.json",
+        Chain.LINEA: "https://reference-data-directory.vercel.app/feeds-ethereum-mainnet-linea-1.json",
+        Chain.CELO: "https://reference-data-directory.vercel.app/feeds-celo-mainnet.json",
     }
 
     def _get_price_feed_info(self, chain: Chain, address: str) -> PriceFeedData | None:

--- a/src/quorum/apis/price_feeds/coingecko_api.py
+++ b/src/quorum/apis/price_feeds/coingecko_api.py
@@ -24,6 +24,8 @@ class CoinGeckoAPI(PriceFeedProviderBase):
         Chain.POLY: "polygon-pos",
         Chain.SCROLL: "scroll",
         Chain.ZK: "zksync",
+        Chain.LINEA: "linea",
+        Chain.CELO: "celo",
     }
 
     COINGECKO_API_URL = (

--- a/src/quorum/auto_report/aave_tags.py
+++ b/src/quorum/auto_report/aave_tags.py
@@ -51,6 +51,7 @@ AAVE_CHAIN_MAPPING = {
         name="zkSync Era", block_explorer_link="https://era.zksync.network/address"
     ),
     "59144": ChainInfo(name="Linea", block_explorer_link="https://lineascan.build/"),
+    "42220": ChainInfo(name="Celo", block_explorer_link="https://celo.blockscout.com/"),
 }
 
 

--- a/src/quorum/utils/chain_enum.py
+++ b/src/quorum/utils/chain_enum.py
@@ -17,4 +17,5 @@ class Chain(StrEnum):
     POLY = "Polygon"
     SCROLL = "Scroll"
     ZK = "zkSync"
-    LINEA = "LINEA"
+    LINEA = "Linea"
+    CELO = "Celo"


### PR DESCRIPTION
https://certora.atlassian.net/browse/CERT-8061

**PR Message:**

Add support for the CELO blockchain

**Summary:**
This PR extends Quorum’s multi-chain functionality by adding support for the CELO network (chain id 42220). The following changes were made:

- **Chain API & Governance:**  
  - Updated `ChainAPI` and `AaveGovernanceAPI` to include CELO in the chain-to-id mappings.
  
- **Price Feed Integrations:**  
  - Added CELO endpoints in both the `ChainLinkAPI` and `CoinGeckoAPI` implementations.

- **Aave Report Tags:**  
  - Extended the `AAVE_CHAIN_MAPPING` in `aave_tags.py` to include CELO with its block explorer URL.

- **Chain Enum:**  
  - Updated the `Chain` enumeration in `chain_enum.py` to add the CELO value.

These modifications enable Quorum to process proposals on the CELO network seamlessly.