### PR TITLE
fix(auto_report): app.aave.com voting link + tolerate un-indexed payload chains (Monad)

### DIFF
--- a/src/quorum/auto_report/aave_tags.py
+++ b/src/quorum/auto_report/aave_tags.py
@@ -81,7 +81,7 @@ def get_aave_tags(proposal_id: int) -> dict[str, Any]:
     # Basic info
     tags["proposal_id"] = str(proposal_id)
     tags["proposal_title"] = ipfs_data.title
-    tags["voting_link"] = f"https://vote.onaave.com/proposal/?proposalId={proposal_id}"
+    tags["voting_link"] = f"https://app.aave.com/governance/v3/proposal/?proposalId={proposal_id}"
     tags["gov_forum_link"] = ipfs_data.discussions
 
     # Multi-chain references

--- a/src/quorum/auto_report/aave_tags.py
+++ b/src/quorum/auto_report/aave_tags.py
@@ -1,9 +1,13 @@
+import logging
 from typing import Any
 
 import json5 as json
 from pydantic import BaseModel
 
-from quorum.apis.governance.aave_governance import AaveGovernanceAPI
+from quorum.apis.governance.aave_governance import (
+    AaveGovernanceAPI,
+    ChainNotFoundException,
+)
 from quorum.apis.governance.data_models import (
     BGDProposalData,
     EventData,
@@ -57,6 +61,7 @@ AAVE_CHAIN_MAPPING = {
         name="Celo", block_explorer_link="https://celo.blockscout.com/address"
     ),
     "146": ChainInfo(name="Sonic", block_explorer_link="https://sonicscan.org/address"),
+    "143": ChainInfo(name="Monad", block_explorer_link="https://monadscan.com/address"),
 }
 
 
@@ -91,25 +96,49 @@ def get_aave_tags(proposal_id: int) -> dict[str, Any]:
 
     # Go through each payload in the proposal
     for p in proposal_data.payloads:
-        # For each payload, retrieve the addresses from the API
-        addresses = api.get_payload_addresses(
-            chain_id=p.chain, controller=p.payloads_controller, payload_id=p.payload_id
+        chain_info = AAVE_CHAIN_MAPPING.get(p.chain)
+        if not chain_info:
+            # Unknown chain — can't build explorer links; skip.
+            continue
+
+        seatbelt_link = (
+            f"{SEATBELT_PAYLOADS_URL}/{p.chain}/{p.payloads_controller}/{p.payload_id}.md"
         )
 
-        # For each address, build up the chain/payload references
-        for i, address in enumerate(addresses, 1):
-            chain_info = AAVE_CHAIN_MAPPING.get(p.chain)
-            if not chain_info:
-                # If chain info is missing, skip
-                continue
+        # Retrieve the payload action addresses. Newly activated networks (e.g.
+        # Monad) may not be indexed in BGD's per-payload cache yet even though the
+        # proposal and its seatbelt report already exist — in that case degrade to
+        # the payloads controller + seatbelt link rather than aborting the report.
+        try:
+            addresses = api.get_payload_addresses(
+                chain_id=p.chain,
+                controller=p.payloads_controller,
+                payload_id=p.payload_id,
+            )
+        except ChainNotFoundException:
+            logging.warning(
+                "BGD payload cache miss for chain %s payload %s (%s); "
+                "emitting controller + seatbelt link only.",
+                p.chain,
+                p.payload_id,
+                p.payloads_controller,
+            )
+            addresses = []
 
-            chain_display = chain_info.name + (f" {i}" if i != 1 else "")
-            tags["chain"].append(chain_display)
-
-            block_explorer_link = f"{chain_info.block_explorer_link}/{address}"
-            tags["payload_link"].append(block_explorer_link)
-
-            seatbelt_link = f"{SEATBELT_PAYLOADS_URL}/{p.chain}/{p.payloads_controller}/{p.payload_id}.md"
+        if addresses:
+            # Build chain/payload references per resolved action address.
+            for i, address in enumerate(addresses, 1):
+                chain_display = chain_info.name + (f" {i}" if i != 1 else "")
+                tags["chain"].append(chain_display)
+                tags["payload_link"].append(f"{chain_info.block_explorer_link}/{address}")
+                tags["payload_seatbelt_link"].append(seatbelt_link)
+        else:
+            # No resolved addresses (cache gap) — still surface the chain, the
+            # payloads controller, and the seatbelt report.
+            tags["chain"].append(chain_info.name)
+            tags["payload_link"].append(
+                f"{chain_info.block_explorer_link}/{p.payloads_controller}"
+            )
             tags["payload_seatbelt_link"].append(seatbelt_link)
 
     # Transaction info

--- a/src/quorum/tests/expected/test_auto_report/v3-132.md
+++ b/src/quorum/tests/expected/test_auto_report/v3-132.md
@@ -1,7 +1,7 @@
 # Proposal 132. Aave v3.1 upgrade
 
 ### Voting Link
-[Link to voting page](https://vote.onaave.com/proposal/?proposalId=132)
+[Link to voting page](https://app.aave.com/governance/v3/proposal/?proposalId=132)
 
 ### Governance Forum Discussion
 [Link to forum discussion](https://governance.aave.com/t/bgd-aave-v3-1-and-aave-origin/17305)


### PR DESCRIPTION
## What

Two related fixes to Aave auto-report generation, both surfaced while bringing the proposal-analysis pipeline up to date for proposal **501 (Aave V3.7 Monad Activation)**.

### 1. `vote.onaave.com` → `app.aave.com`
`vote.onaave.com` has been sunset. The generated report's **Voting Link** now points at the canonical governance UI: `https://app.aave.com/governance/v3/proposal/?proposalId=<id>`.

### 2. Tolerate payload chains not yet in the BGD cache (e.g. Monad)
Newly activated networks (Monad, chain `143`) may not be indexed in BGD's per-payload governance cache even though the proposal *and its seatbelt report* already exist. `get_payload_addresses` raises `ChainNotFoundException` on the resulting 404, which **aborted the entire report**.

- Catch `ChainNotFoundException` in the report path and degrade gracefully: emit the payloads controller address + seatbelt link (with a warning) instead of failing. The strict `validate-by-id` semantics are unchanged.
- Add Monad (`143`) to `AAVE_CHAIN_MAPPING` (monadscan explorer).

## Verification

- `generate-report --proposal-id 501` now produces a complete report — title, app.aave.com voting link, forum, payloads (Monad → monadscan), creator/IPFS/tx data, and **both Monad payload Seatbelt links**. Previously it crashed with `ChainNotFoundException`.
- `pytest src/quorum/tests/test_auto_report.py` (proposal 132, Ethereum / normal path) still passes; golden fixture refreshed for the new voting-link host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)